### PR TITLE
Verilog flavour added

### DIFF
--- a/sim/prince_axis_tb.v
+++ b/sim/prince_axis_tb.v
@@ -1,0 +1,95 @@
+`ifdef TIMESCALE
+        `timescale 1ns/10ps
+`endif
+
+module prince_axis_tb();
+
+`include "prince_tb_features.v"
+
+   // --Inputs
+   reg ACLK = 0;
+   reg ARESETN = 0;
+   reg [DATA_SIZE-1:0] S_AXIS_TDATA = {DATA_SIZE{1'b0}};
+   reg S_AXIS_TLAST = 0;
+   reg S_AXIS_TVALID = 0;
+   reg M_AXIS_TREADY = 0;
+
+   // --Outputs
+   wire S_AXIS_TREADY;
+   wire M_AXIS_TVALID;
+   wire [DATA_SIZE-1:0] M_AXIS_TDATA;
+   wire M_AXIS_TLAST ;
+
+   //-- Clock period definitions
+   parameter CLK_PERIOD = 10;
+   
+   //-- Other signals
+   reg [63:0] ciphertext;
+
+//-- Instantiate the Unit Under Test (UUT)
+
+	axi_stream_wrapper uut (
+        //-- inputs
+        .ACLK(ACLK),
+        .ARESETN(ARESETN),
+        .S_AXIS_TDATA(S_AXIS_TDATA),
+        .S_AXIS_TLAST(S_AXIS_TLAST),
+        .M_AXIS_TREADY(M_AXIS_TREADY),
+        .S_AXIS_TVALID(S_AXIS_TVALID),
+        //-- outputs
+        .M_AXIS_TVALID(M_AXIS_TVALID),
+        .M_AXIS_TLAST(M_AXIS_TLAST),
+        .M_AXIS_TDATA(M_AXIS_TDATA),
+        .S_AXIS_TREADY(S_AXIS_TREADY)
+        );
+
+
+initial begin
+  $dumpfile ("prince_axis_tb.vcd");
+  $dumpvars;
+end
+
+always @(*)
+  ACLK <= #(CLK_PERIOD/2) ~ACLK;
+
+initial begin
+      $display("-I- prince simulation thru AXI stream prototol");
+      ARESETN = 0;
+	#(10 * CLK_PERIOD);
+
+      // -- write plaintext
+      ARESETN = 1;
+      S_AXIS_TVALID = 1;
+      S_AXIS_TDATA <= 32'h01234567;
+      #(CLK_PERIOD); 
+      #(CLK_PERIOD);
+      S_AXIS_TDATA <= 32'h89ABCDEF;
+      #(CLK_PERIOD);
+      
+      //-- write key (k0 first then k1)
+      S_AXIS_TDATA = {DATA_SIZE{1'b0}};
+      #(CLK_PERIOD*2);
+      S_AXIS_TDATA = 32'hFEDCBA98;
+      #(CLK_PERIOD);
+      S_AXIS_TDATA = 32'h76543210;
+      #(CLK_PERIOD);
+      S_AXIS_TDATA = {DATA_SIZE{1'b0}};
+      S_AXIS_TVALID = 0;
+      #(CLK_PERIOD);
+      
+      //-- read ciphertext
+      M_AXIS_TREADY = 1;
+      #(CLK_PERIOD);
+      ciphertext[63:32] = M_AXIS_TDATA;
+      #(CLK_PERIOD);
+      ciphertext[31:0] = M_AXIS_TDATA;
+      #(CLK_PERIOD);
+      M_AXIS_TREADY = 0;
+      
+      //-- print ciphertext
+      $display("cipĥertext is %h and expected value is ae25ad3ca8fa9ccf", ciphertext);
+
+      $finish;
+end
+
+endmodule

--- a/sim/prince_tb.v
+++ b/sim/prince_tb.v
@@ -1,0 +1,71 @@
+`ifdef TIMESCALE
+	`timescale 1ns/10ps
+`endif
+
+module prince_tb();
+
+parameter CLK_PERIOD = 100;
+parameter TEXT_SIZE = 64;
+parameter KEY_SIZE = 128;
+parameter SBOX_NUMBER = 16;
+
+reg [TEXT_SIZE-1:0] plaintext = {TEXT_SIZE{1'b0}}; 
+wire [TEXT_SIZE-1:0] ciphertext; 
+reg [KEY_SIZE-1:0] key = {KEY_SIZE{1'b0}}; 
+
+
+prince_top #(
+	.TEXT_SIZE(TEXT_SIZE),
+	.KEY_SIZE(KEY_SIZE),
+	.SBOX_NUMBER(SBOX_NUMBER)
+) uut (
+	.plaintext(plaintext),
+	.key(key),
+	.ciphertext(ciphertext)
+);
+
+initial begin
+
+   //-- Stimulus process
+  
+      //-- hold reset state for 100 ns.
+      #CLK_PERIOD;
+
+      //-- Test vectors from the PRINCE paper
+      //-- First test vector
+      plaintext = {TEXT_SIZE{1'b0}};
+      key = {KEY_SIZE{1'b0}};
+      #1;
+      $display("cipĥertext is %h and expected value is 818665aa0d02dfda", ciphertext);
+      #9;
+
+      //-- Second test vector
+      plaintext = {TEXT_SIZE{1'b1}};
+      key = {KEY_SIZE{1'b0}};
+      #1;
+      $display("cipĥertext is %h and expected value is 604ae6ca03c20ada", ciphertext);
+      #9;
+
+      //-- Third test vector
+      plaintext = {TEXT_SIZE{1'b0}};
+      key = {{KEY_SIZE/2{1'b1}}, {KEY_SIZE/2{1'b0}}};
+      #1;
+      $display("cipĥertext is %h and expected value is 9fb51935fc3df524", ciphertext);
+      #9;
+
+      //-- Fourth test vector
+      plaintext = {TEXT_SIZE{1'b0}};
+      key = {{KEY_SIZE/2{1'b0}}, {KEY_SIZE/2{1'b1}}};
+      #1;
+      $display("cipĥertext is %h and expected value is 78a54cbe737bb7ef", ciphertext);
+      #9;
+
+      //-- Fifth test vector
+      plaintext = {{(TEXT_SIZE-64){1'b0}}, 64'h0123456789abcdef};
+      key = {{(KEY_SIZE-64){1'b0}}, 64'hfedcba9876543210};
+      #1;
+      $display("cipĥertext is %h and expected value is ae25ad3ca8fa9ccf", ciphertext);
+
+end
+
+endmodule

--- a/sim/prince_tb_features.v
+++ b/sim/prince_tb_features.v
@@ -1,0 +1,4 @@
+//-- $Id: prince_tb_features.v,v 1.1 2021/01/04 13:00:51 brunom Exp $
+
+parameter DATA_SIZE = 32;
+parameter ADDR_SIZE = 32;

--- a/sim/prince_tb_features.v
+++ b/sim/prince_tb_features.v
@@ -1,4 +1,2 @@
-//-- $Id: prince_tb_features.v,v 1.1 2021/01/04 13:00:51 brunom Exp $
-
 parameter DATA_SIZE = 32;
 parameter ADDR_SIZE = 32;

--- a/verilog/axi_stream_wrapper.v
+++ b/verilog/axi_stream_wrapper.v
@@ -1,0 +1,111 @@
+module axi_stream_wrapper (
+  input wire ACLK, //-- positive edge clock
+  input wire ARESETN, //-- active-low asynchronous reset
+  input wire [31:0] S_AXIS_TDATA,
+  input wire S_AXIS_TLAST,
+  input wire M_AXIS_TREADY,
+  input wire S_AXIS_TVALID,
+  output wire M_AXIS_TVALID,
+  output reg [31:0] M_AXIS_TDATA,
+  output wire M_AXIS_TLAST,
+  output wire S_AXIS_TREADY
+);
+
+parameter FSM_SIZE = 2;
+parameter COUNTER_SIZE = 2;
+//-- states
+parameter IDLE = 2'b00;
+parameter READ_PLAINTEXT = 2'b01;
+parameter READ_KEY = 2'b11;
+parameter WRITE_CIPHERTEXT = 2'b10;
+
+parameter PLAINTEXT_READS = 3'b010;
+parameter KEY_READS = 3'b100;
+parameter CIPHERTEXT_WRITES = 3'b010;
+
+
+reg [FSM_SIZE-1:0] state; //-- state_machine
+reg [COUNTER_SIZE-1:0] counter; 
+
+reg [31:0] ip_key_buf [3:0];
+reg [31:0] ip_plaintext_buf [1:0];
+wire [31:0] ip_ciphertext_buf [1:0];
+
+wire [127:0] ip_key;
+wire [63:0] ip_plaintext;
+wire [63:0] ip_ciphertext;
+
+wire mode = 0; //--enc mode by default. to be placed in a cfg reg
+
+prince_top #(
+        .TEXT_SIZE(64),
+        .KEY_SIZE(128),
+        .SBOX_NUMBER(16)
+) i_prince_top (
+        .plaintext(ip_plaintext),
+        .key(ip_key),
+        .mode(mode),
+        .ciphertext(ip_ciphertext)
+        );
+
+assign ip_plaintext = {ip_plaintext_buf[0], ip_plaintext_buf[1]};
+assign ip_key = {ip_key_buf[0], ip_key_buf[1] , ip_key_buf[2] , ip_key_buf[3]};
+assign ip_ciphertext_buf[0] = ip_ciphertext[63:32];
+assign ip_ciphertext_buf[1] = ip_ciphertext[31:0];
+
+assign S_AXIS_TREADY = (state == READ_PLAINTEXT || state == READ_KEY);
+assign M_AXIS_TVALID = (state == WRITE_CIPHERTEXT);
+assign M_AXIS_TLAST = (state == WRITE_CIPHERTEXT) && (counter == (CIPHERTEXT_WRITES-1));
+
+  always @(negedge ARESETN or posedge ACLK)
+    if(~ARESETN) begin
+      state <= IDLE;
+      counter <= 0;
+    end
+    else begin
+      case(state)
+      IDLE: begin
+        M_AXIS_TDATA <= {32{1'b0}};
+        if(S_AXIS_TVALID == 1) begin
+          state <= READ_PLAINTEXT;
+          counter <= 0;
+        end
+      end
+      READ_PLAINTEXT: begin
+        if(S_AXIS_TVALID == 1) begin
+          ip_plaintext_buf[counter] <= S_AXIS_TDATA;
+          if(counter == (PLAINTEXT_READS - 1)) begin
+            state <= READ_KEY;
+            counter <= 0;
+          end
+          else 
+            counter <= counter + 1;
+        end
+      end
+      READ_KEY: begin
+        if(S_AXIS_TVALID == 1) begin
+          ip_key_buf[counter] <= S_AXIS_TDATA;
+          if(counter == (KEY_READS - 1)) begin
+            state <= WRITE_CIPHERTEXT;
+            counter <= 0;
+          end
+          else begin
+            counter <= counter + 1;
+          end
+        end
+      end
+      WRITE_CIPHERTEXT: begin
+        M_AXIS_TDATA <= ip_ciphertext_buf[counter];
+        if(M_AXIS_TREADY == 1) begin
+          if(counter == (CIPHERTEXT_WRITES - 1)) begin
+            state <= IDLE;
+            counter <= 0;
+          end
+          else
+            counter <= counter + 1;
+        end
+      end
+      endcase
+    end
+
+endmodule

--- a/verilog/linear_m.v
+++ b/verilog/linear_m.v
@@ -1,0 +1,34 @@
+//-- This entity applies the matrix from linear_mprime.
+//-- In addition, a nibble-wise
+//-- transposition is performed in the end.
+
+module linear_m(
+  input [63:0] data_in,
+  output wire [63:0] data_out
+);
+
+wire [63:0] mprime_out;
+
+linear_mprime i_linear_mprime (
+  .data_in(data_in),
+  .data_out(mprime_out)
+);
+
+  assign data_out[63:60] = mprime_out[63:60];
+  assign data_out[59:56] = mprime_out[43:40];
+  assign data_out[55:52] = mprime_out[23:20];
+  assign data_out[51:48] = mprime_out[3:0];
+  assign data_out[47:44] = mprime_out[47:44];
+  assign data_out[43:40] = mprime_out[27:24];
+  assign data_out[39:36] = mprime_out[7:4];
+  assign data_out[35:32] = mprime_out[51:48];
+  assign data_out[31:28] = mprime_out[31:28];
+  assign data_out[27:24] = mprime_out[11:8];
+  assign data_out[23:20] = mprime_out[55:52];
+  assign data_out[19:16] = mprime_out[35:32];
+  assign data_out[15:12] = mprime_out[15:12];
+  assign data_out[11:8] = mprime_out[59:56];
+  assign data_out[7:4] = mprime_out[39:36];
+  assign data_out[3:0] = mprime_out[19:16];
+
+endmodule

--- a/verilog/linear_m_inv.v
+++ b/verilog/linear_m_inv.v
@@ -1,0 +1,30 @@
+module linear_m_inv (
+  input [63:0] data_in,
+  output wire [63:0] data_out
+);
+
+wire [63:0] mprime_in;
+
+assign mprime_in[63:60] = data_in[63:60];
+assign mprime_in[59:56] = data_in[11:8];
+assign mprime_in[55:52] = data_in[23:20];
+assign mprime_in[51:48] = data_in[35:32];
+assign mprime_in[47:44] = data_in[47:44];
+assign mprime_in[43:40] = data_in[59:56];
+assign mprime_in[39:36] = data_in[7:4];
+assign mprime_in[35:32] = data_in[19:16];
+assign mprime_in[31:28] = data_in[31:28];
+assign mprime_in[27:24] = data_in[43:40];
+assign mprime_in[23:20] = data_in[55:52];
+assign mprime_in[19:16] = data_in[3:0];
+assign mprime_in[15:12] = data_in[15:12];
+assign mprime_in[11:8] = data_in[27:24];
+assign mprime_in[7:4] = data_in[39:36];
+assign mprime_in[3:0] = data_in[51:48];
+
+linear_mprime u_linear_mprime (
+  .data_in(mprime_in),
+  .data_out(data_out)
+);
+
+endmodule

--- a/verilog/linear_mprime.v
+++ b/verilog/linear_mprime.v
@@ -1,0 +1,76 @@
+//-- Linear layer of PRINCE
+//-- This entity multiplies the 64 bit state with a fixed 64x64 matrix. Each row
+//-- and column of this matrix has exactly 3 bits set to 1, while the rest is
+//-- set to 0.
+
+module linear_mprime(
+  input [63:0] data_in,
+  output wire [63:0] data_out
+);
+
+assign data_out[63] = data_in[59] ^ data_in[55] ^ data_in[51];
+assign data_out[62] = data_in[62] ^ data_in[54] ^ data_in[50];
+assign data_out[61] = data_in[61] ^ data_in[57] ^ data_in[49];
+assign data_out[60] = data_in[60] ^ data_in[56] ^ data_in[52];
+assign data_out[59] = data_in[63] ^ data_in[59] ^ data_in[55];
+assign data_out[58] = data_in[58] ^ data_in[54] ^ data_in[50];
+assign data_out[57] = data_in[61] ^ data_in[53] ^ data_in[49];
+assign data_out[56] = data_in[60] ^ data_in[56] ^ data_in[48];
+assign data_out[55] = data_in[63] ^ data_in[59] ^ data_in[51];
+assign data_out[54] = data_in[62] ^ data_in[58] ^ data_in[54];
+assign data_out[53] = data_in[57] ^ data_in[53] ^ data_in[49];
+assign data_out[52] = data_in[60] ^ data_in[52] ^ data_in[48];
+assign data_out[51] = data_in[63] ^ data_in[55] ^ data_in[51];
+assign data_out[50] = data_in[62] ^ data_in[58] ^ data_in[50];
+assign data_out[49] = data_in[61] ^ data_in[57] ^ data_in[53];
+assign data_out[48] = data_in[56] ^ data_in[52] ^ data_in[48];
+assign data_out[47] = data_in[47] ^ data_in[43] ^ data_in[39];
+assign data_out[46] = data_in[42] ^ data_in[38] ^ data_in[34];
+assign data_out[45] = data_in[45] ^ data_in[37] ^ data_in[33];
+assign data_out[44] = data_in[44] ^ data_in[40] ^ data_in[32];
+assign data_out[43] = data_in[47] ^ data_in[43] ^ data_in[35];
+assign data_out[42] = data_in[46] ^ data_in[42] ^ data_in[38];
+assign data_out[41] = data_in[41] ^ data_in[37] ^ data_in[33];
+assign data_out[40] = data_in[44] ^ data_in[36] ^ data_in[32];
+assign data_out[39] = data_in[47] ^ data_in[39] ^ data_in[35];
+assign data_out[38] = data_in[46] ^ data_in[42] ^ data_in[34];
+assign data_out[37] = data_in[45] ^ data_in[41] ^ data_in[37];
+assign data_out[36] = data_in[40] ^ data_in[36] ^ data_in[32];
+assign data_out[35] = data_in[43] ^ data_in[39] ^ data_in[35];
+assign data_out[34] = data_in[46] ^ data_in[38] ^ data_in[34];
+assign data_out[33] = data_in[45] ^ data_in[41] ^ data_in[33];
+assign data_out[32] = data_in[44] ^ data_in[40] ^ data_in[36];
+assign data_out[31] = data_in[31] ^ data_in[27] ^ data_in[23];
+assign data_out[30] = data_in[26] ^ data_in[22] ^ data_in[18];
+assign data_out[29] = data_in[29] ^ data_in[21] ^ data_in[17];
+assign data_out[28] = data_in[28] ^ data_in[24] ^ data_in[16];
+assign data_out[27] = data_in[31] ^ data_in[27] ^ data_in[19];
+assign data_out[26] = data_in[30] ^ data_in[26] ^ data_in[22];
+assign data_out[25] = data_in[25] ^ data_in[21] ^ data_in[17];
+assign data_out[24] = data_in[28] ^ data_in[20] ^ data_in[16];
+assign data_out[23] = data_in[31] ^ data_in[23] ^ data_in[19];
+assign data_out[22] = data_in[30] ^ data_in[26] ^ data_in[18];
+assign data_out[21] = data_in[29] ^ data_in[25] ^ data_in[21];
+assign data_out[20] = data_in[24] ^ data_in[20] ^ data_in[16];
+assign data_out[19] = data_in[27] ^ data_in[23] ^ data_in[19];
+assign data_out[18] = data_in[30] ^ data_in[22] ^ data_in[18];
+assign data_out[17] = data_in[29] ^ data_in[25] ^ data_in[17];
+assign data_out[16] = data_in[28] ^ data_in[24] ^ data_in[20];
+assign data_out[15] = data_in[11] ^ data_in[7] ^ data_in[3];
+assign data_out[14] = data_in[14] ^ data_in[6] ^ data_in[2];
+assign data_out[13] = data_in[13] ^ data_in[9] ^ data_in[1];
+assign data_out[12] = data_in[12] ^ data_in[8] ^ data_in[4];
+assign data_out[11] = data_in[15] ^ data_in[11] ^ data_in[7];
+assign data_out[10] = data_in[10] ^ data_in[6] ^ data_in[2];
+assign data_out[9] = data_in[13] ^ data_in[5] ^ data_in[1];
+assign data_out[8] = data_in[12] ^ data_in[8] ^ data_in[0];
+assign data_out[7] = data_in[15] ^ data_in[11] ^ data_in[3];
+assign data_out[6] = data_in[14] ^ data_in[10] ^ data_in[6];
+assign data_out[5] = data_in[9] ^ data_in[5] ^ data_in[1];
+assign data_out[4] = data_in[12] ^ data_in[4] ^ data_in[0];
+assign data_out[3] = data_in[15] ^ data_in[7] ^ data_in[3];
+assign data_out[2] = data_in[14] ^ data_in[10] ^ data_in[2];
+assign data_out[1] = data_in[13] ^ data_in[9] ^ data_in[5];
+assign data_out[0] = data_in[8] ^ data_in[4] ^ data_in[0];
+
+endmodule

--- a/verilog/prince_core.v
+++ b/verilog/prince_core.v
@@ -1,0 +1,190 @@
+module prince_core
+	#( parameter TEXT_SIZE=64,
+        parameter KEY_SIZE=128,
+	parameter SBOX_NUMBER=16) (
+	input [TEXT_SIZE-1:0] data_in,
+	input [KEY_SIZE/2-1:0] key,
+	output wire [TEXT_SIZE-1:0] data_out
+	);
+
+wire [TEXT_SIZE-1:0] rcs [11:0];
+wire [TEXT_SIZE-1:0] ims [11:0];
+
+wire [TEXT_SIZE-1:0] sb_out[5:1];
+wire [TEXT_SIZE-1:0] m_out[5:1];
+
+wire [TEXT_SIZE-1:0] sb_in[10:6];
+wire [TEXT_SIZE-1:0] m_in[10:6];
+
+wire [TEXT_SIZE-1:0] middle1, middle2;
+
+// -- Round constants for each round
+assign rcs[0] = 64'h0000000000000000;
+assign rcs[1] = 64'h13198A2E03707344;
+assign rcs[2] = 64'hA4093822299F31D0;
+assign rcs[3] = 64'h082EFA98EC4E6C89;
+assign rcs[4] = 64'h452821E638D01377;
+assign rcs[5] = 64'hBE5466CF34E90C6C;
+assign rcs[6] = 64'h7EF84F78FD955CB1;
+assign rcs[7] = 64'h85840851F1AC43AA;
+assign rcs[8] = 64'hC882D32F25323C54;
+assign rcs[9] = 64'h64A51195E0E3610D;
+assign rcs[10] = 64'hD3B5A399CA0C2399;
+assign rcs[11] = 64'hC0AC29B7C97C50DD;
+
+genvar i,j;
+
+//-- instantiates sbox, sbox_inv, linear_m, 
+
+//-- Round 0
+assign ims[0] = data_in ^  key ^ rcs[0]; 
+
+//-- Round 1 to 5
+generate
+  for (j = 0 ; j <= (SBOX_NUMBER-1) ; j = j + 1) begin
+    sbox i_sbox (
+      .data_in(ims[0][63 - 4*j:63 - 4*j - 3]),
+      .data_out(sb_out[1][63 - 4*j:63- 4*j - 3])
+     );
+   end
+endgenerate
+
+generate
+  for (j = 0 ; j <= (SBOX_NUMBER-1) ; j = j + 1) begin
+    sbox i_sbox (
+      .data_in(ims[1][63 - 4*j:63 - 4*j - 3]),
+      .data_out(sb_out[2][63 - 4*j:63- 4*j - 3])
+     );
+   end
+endgenerate
+
+generate
+  for (j = 0 ; j <= (SBOX_NUMBER-1) ; j = j + 1) begin
+    sbox i_sbox (
+      .data_in(ims[2][63 - 4*j:63 - 4*j - 3]),
+      .data_out(sb_out[3][63 - 4*j:63- 4*j - 3])
+     );
+   end
+endgenerate
+
+generate
+  for (j = 0 ; j <= (SBOX_NUMBER-1) ; j = j + 1) begin
+    sbox i_sbox (
+      .data_in(ims[3][63 - 4*j:63 - 4*j - 3]),
+      .data_out(sb_out[4][63 - 4*j:63- 4*j - 3])
+     );
+   end
+endgenerate
+
+generate
+  for (j = 0 ; j <= (SBOX_NUMBER-1) ; j = j + 1) begin
+    sbox i_sbox (
+      .data_in(ims[4][63 - 4*j:63 - 4*j - 3]),
+      .data_out(sb_out[5][63 - 4*j:63- 4*j - 3])
+     );
+   end
+endgenerate
+
+generate
+  for (i = 1 ; i <= 5 ; i = i + 1) begin
+
+  linear_m i_linear_m (
+	.data_in(sb_out[i]),
+	.data_out(m_out[i])
+	);
+
+  assign ims[i] = m_out[i] ^  key ^ rcs[i]; 
+
+  end
+endgenerate
+
+
+//-- Middle Layer
+
+generate
+  for (j = 0 ; j <= (SBOX_NUMBER-1) ; j = j + 1) begin
+    sbox i_sbox (
+      .data_in(ims[5][63 - 4*j:63 - 4*j - 3]),
+      .data_out(middle1[63 - 4*j:63- 4*j - 3])
+     );
+   end
+endgenerate
+
+linear_mprime i_linear_mprime (
+  .data_in(middle1),
+  .data_out(middle2)
+);
+
+generate
+  for (j = 0 ; j <= (SBOX_NUMBER-1) ; j = j + 1) begin
+    sbox_inv i_sbox_inv (
+      .data_in(middle2[63 - 4*j:63 - 4*j - 3]),
+      .data_out(ims[6][63 - 4*j:63- 4*j - 3])
+     );
+   end
+endgenerate
+
+//-- Round 6 to 10
+
+generate
+  for (i = 6 ; i <= 10 ; i = i + 1) begin
+
+  assign m_in[i] = ims[i] ^  key ^ rcs[i];
+
+  linear_m_inv i_linear_m_inv (
+        .data_in(m_in[i]),
+        .data_out(sb_in[i])
+        );
+
+  end
+endgenerate
+
+generate
+  for (j = 0 ; j <= (SBOX_NUMBER-1) ; j = j + 1) begin
+    sbox_inv i_sbox_inv (
+      .data_in(sb_in[6][63 - 4*j:63 - 4*j - 3]),
+      .data_out(ims[7][63 - 4*j:63- 4*j - 3])
+     );
+   end
+endgenerate
+
+generate
+  for (j = 0 ; j <= (SBOX_NUMBER-1) ; j = j + 1) begin
+    sbox_inv i_sbox_inv (
+      .data_in(sb_in[7][63 - 4*j:63 - 4*j - 3]),
+      .data_out(ims[8][63 - 4*j:63- 4*j - 3])
+     );
+   end
+endgenerate
+
+generate
+  for (j = 0 ; j <= (SBOX_NUMBER-1) ; j = j + 1) begin
+    sbox_inv i_sbox_inv (
+      .data_in(sb_in[8][63 - 4*j:63 - 4*j - 3]),
+      .data_out(ims[9][63 - 4*j:63- 4*j - 3])
+     );
+   end
+endgenerate
+
+generate
+  for (j = 0 ; j <= (SBOX_NUMBER-1) ; j = j + 1) begin
+    sbox_inv i_sbox_inv (
+      .data_in(sb_in[9][63 - 4*j:63 - 4*j - 3]),
+      .data_out(ims[10][63 - 4*j:63- 4*j - 3])
+     );
+   end
+endgenerate
+
+generate
+  for (j = 0 ; j <= (SBOX_NUMBER-1) ; j = j + 1) begin
+    sbox_inv i_sbox_inv (
+      .data_in(sb_in[10][63 - 4*j:63 - 4*j - 3]),
+      .data_out(ims[11][63 - 4*j:63- 4*j - 3])
+     );
+   end
+endgenerate
+
+//-- Round 11
+assign data_out = ims[11] ^ key ^ rcs[11]; 
+
+endmodule

--- a/verilog/prince_top.v
+++ b/verilog/prince_top.v
@@ -1,0 +1,61 @@
+module prince_top
+#( parameter TEXT_SIZE=64,
+	parameter KEY_SIZE=128,
+	parameter SBOX_NUMBER=16) (
+  input [TEXT_SIZE-1:0] plaintext, //-- 64 bit plaintext block
+  input [KEY_SIZE-1:0] key, //-- 128 bit key
+  input mode, //-- crypto mode 0=enc, 1=dec
+  output wire [TEXT_SIZE-1:0] ciphertext //-- 64 bit encrypted block
+);
+
+//-- Intermediate signals for splitting the key into the whitening keys k0
+//-- and k0_end, and the key k1 which is used in prince_core
+
+reg [KEY_SIZE/2-1:0] k0_start;
+reg [KEY_SIZE/2-1:0] k0_end;
+reg [KEY_SIZE/2-1:0] k1;
+
+wire [KEY_SIZE/2-1:0] alpha = {{(KEY_SIZE/2-64){1'b0}}, 64'hC0AC29B7C97C50DD};
+
+//-- Data I/O for prince_core
+
+wire [TEXT_SIZE-1:0] core_in, core_out;
+
+//-- Key extension/whitening keys
+
+always @(*)
+	case(mode)
+		1'b0: begin //-- encryption
+                      k0_start = key[127:64];
+                      k0_end = {key[64],key[127:66],(key[65] ^ key[127])};
+                      k1 = key[63:0];
+		end
+		1'b1: begin //-- decryption
+                      k0_start = {key[64],key[127:66],(key[65] ^ key[127])};
+                      k0_end = key[127:64];
+                      k1 = key[63:0] ^ alpha;
+		end
+		default: begin //-- encryption by default
+                      k0_start = key[127:64];
+                      k0_end = {key[64],key[127:66],(key[65] ^ key[127])};
+                      k1 = key[63:0];
+		end
+	endcase
+
+
+//-- prince_core instance
+  
+assign core_in = plaintext ^ k0_start;
+assign ciphertext = core_out ^ k0_end;
+
+prince_core #(
+	.TEXT_SIZE(TEXT_SIZE),
+	.KEY_SIZE(KEY_SIZE),
+	.SBOX_NUMBER(SBOX_NUMBER)
+) i_prince_core (
+    .data_in(core_in),
+    .key(k1),
+    .data_out(core_out)
+    );
+
+endmodule

--- a/verilog/sbox.v
+++ b/verilog/sbox.v
@@ -1,0 +1,64 @@
+//-- Substitution box of PRINCE
+
+module sbox(
+  input wire [3:0] data_in,
+  output reg [3:0] data_out
+);
+
+  always @(data_in) begin
+    case(data_in)
+    4'h0 : begin
+      data_out <= 4'hB;
+    end
+    4'h1 : begin
+      data_out <= 4'hF;
+    end
+    4'h2 : begin
+      data_out <= 4'h3;
+    end
+    4'h3 : begin
+      data_out <= 4'h2;
+    end
+    4'h4 : begin
+      data_out <= 4'hA;
+    end
+    4'h5 : begin
+      data_out <= 4'hC;
+    end
+    4'h6 : begin
+      data_out <= 4'h9;
+    end
+    4'h7 : begin
+      data_out <= 4'h1;
+    end
+    4'h8 : begin
+      data_out <= 4'h6;
+    end
+    4'h9 : begin
+      data_out <= 4'h7;
+    end
+    4'hA : begin
+      data_out <= 4'h8;
+    end
+    4'hB : begin
+      data_out <= 4'h0;
+    end
+    4'hC : begin
+      data_out <= 4'hE;
+    end
+    4'hD : begin
+      data_out <= 4'h5;
+    end
+    4'hE : begin
+      data_out <= 4'hD;
+    end
+    4'hF : begin
+      data_out <= 4'h4;
+    end
+    default : begin
+      data_out <= 4'hx;
+    end
+    endcase
+  end
+
+endmodule

--- a/verilog/sbox_inv.v
+++ b/verilog/sbox_inv.v
@@ -1,0 +1,64 @@
+//-- Inverted substitution box of PRINCE
+
+module sbox_inv(
+  input [3:0] data_in,
+  output reg [3:0] data_out
+);
+
+  always @(data_in) begin
+    case(data_in)
+    4'h0 : begin
+      data_out <= 4'hB;
+    end
+    4'h1 : begin
+      data_out <= 4'h7;
+    end
+    4'h2 : begin
+      data_out <= 4'h3;
+    end
+    4'h3 : begin
+      data_out <= 4'h2;
+    end
+    4'h4 : begin
+      data_out <= 4'hF;
+    end
+    4'h5 : begin
+      data_out <= 4'hD;
+    end
+    4'h6 : begin
+      data_out <= 4'h8;
+    end
+    4'h7 : begin
+      data_out <= 4'h9;
+    end
+    4'h8 : begin
+      data_out <= 4'hA;
+    end
+    4'h9 : begin
+      data_out <= 4'h6;
+    end
+    4'hA : begin
+      data_out <= 4'h4;
+    end
+    4'hB : begin
+      data_out <= 4'h0;
+    end
+    4'hC : begin
+      data_out <= 4'h5;
+    end
+    4'hD : begin
+      data_out <= 4'hE;
+    end
+    4'hE : begin
+      data_out <= 4'hC;
+    end
+    4'hF : begin
+      data_out <= 4'h1;
+    end
+    default : begin
+      data_out <= 4'hx;
+    end
+    endcase
+  end
+
+endmodule


### PR DESCRIPTION
This is a translation to the Verilog-2001 language in order to simulate the Prince algorithm with the open-source Icarus verilog simulator. 
Some potential future developments :
- To add a register interface for key and data load/store on an AMBA APB I/F
- To integrate the algorithm to a SRAM or NVM controller I/F